### PR TITLE
Filter should be case insensitive

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -22,6 +22,7 @@ func main() {
 
 func (p *Plugin) OnActivate() error {
 	p.badWords = make(map[string]bool, len(badWords))
+	word := string.ToLower(word)
 	for _, word := range badWords {
 		p.badWords[word] = true
 	}
@@ -37,6 +38,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 }
 
 func (p *Plugin) WordIsBad(word string) bool {
+	word := string.ToLower(word)
 	_, ok := p.badWords[word]
 	return ok
 }


### PR DESCRIPTION
All words to be filtered should be lower-case, regardless of how entered.  Word to be compared should be lower-case, regardless of how entered.

Closes mattermost/mattermost-plugin-profanity-filter#11